### PR TITLE
reportFile option wasn't been passed though to the exec command. grun…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Number of tests to run concurrently
 Type: `Number`
 Default value: `2`
 
-Level of logging --   
+Level of logging --
 `2`: All output  
 `1`: Only error output  
 `0`: No output
@@ -142,12 +142,12 @@ Type: `String`
 
 Path to output a istanbul coverage report to, must be an empty directory.  If the directory does not exist it will be created for you
 
-#### options.reportFile
+#### options.coverage.reportFile
 Type: `String`
 
 Path to output a basic coverage report file to, the file will be in a `lcov` format.  If the file does not exist it will be created for you.
 
-#### options.sourcePrefix
+#### options.coverage.sourcePrefix
 Type: `String`
 
 The relative path to the original source file for use in the coverage results.

--- a/tasks/grover.js
+++ b/tasks/grover.js
@@ -8,6 +8,7 @@
 
 'use strict';
 var exec = require('child_process').exec,
+    grunt = require('grunt'),
     path = require('path'),
     glob = require('glob'),
     phantom = require('phantomjs'),
@@ -146,6 +147,7 @@ module.exports = function(grunt) {
             }
             if (typeof options.coverage.reportFile === 'string') {
                 grunt.file.write(options.coverage.reportFile, '');
+                cmd += ' -co ' + path.normalize(options.coverage.reportFile);
             }
             cmd += pathVar(options.coverage.sourcePrefix, 'sp');
         }


### PR DESCRIPTION
reportFile option wasn't been passed though to the exec command. grunt variable wasn't in scope for the helper functions. Couple of documentation issues in the readme.
