### PR TITLE
Adding ability to pass cwd to grover execution

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
       default_options: {
         options: {
           path: 'test/js/*.html',
+          'execution-path': '../..',
           logLevel: 2,
           failOnFirst: false,
           concurrent: 15,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
       default_options: {
         options: {
           path: 'test/js/*.html',
-          'execution-path': '../..',
+          cwd: '../..',
           logLevel: 2,
           failOnFirst: false,
           concurrent: 15,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,6 @@ module.exports = function(grunt) {
       default_options: {
         options: {
           path: 'test/js/*.html',
-          cwd: '../..',
           logLevel: 2,
           failOnFirst: false,
           concurrent: 15,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Type: `String`
 
 A glob format path to your YUI test files.  E.g. `'test/js/*.html'`
 
+#### options[execution-path]
+Type: 'String'
+
+The path on which to execute the grover command
+
 #### options.concurrent
 Type: `Number`  
 Default value: `15`
@@ -184,3 +189,4 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ## Release History
 **0.1.0: ** *15/02/2015*
 **0.2.3: ** *5/08/2015*
+**0.2.4: ** *28/9/2015*

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ grunt.initConfig({
     default: {
       options: {
           path: 'test/js/*.html',
+          'execution-path': 'target/combined-sources',
           logLevel: 2,
           concurrent: 15,
           outfile: 'reports/grover.tap',

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Type: `String`
 
 A glob format path to your YUI test files.  E.g. `'test/js/*.html'`
 
-#### options[execution-path]
+#### options.cwd
 Type: 'String'
 
 The path on which to execute the grover command
@@ -170,7 +170,7 @@ grunt.initConfig({
     default: {
       options: {
           path: 'test/js/*.html',
-          'execution-path': 'target/combined-sources',
+          cwd: 'target/combined-sources',
           logLevel: 2,
           concurrent: 15,
           outfile: 'reports/grover.tap',

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ grunt.initConfig({
     default: {
       options: {
           path: 'test/js/*.html',
-          cwd: 'target/combined-sources',
           logLevel: 2,
           concurrent: 15,
           outfile: 'reports/grover.tap',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-grover",
   "description": "A grunt task to run yui tests with grover",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "homepage": "https://github.com/MarshallOfSound/grunt-grover",
   "author": {
     "name": "Samuel Attard",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-grover",
   "description": "A grunt task to run yui tests with grover",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://github.com/MarshallOfSound/grunt-grover",
   "author": {
     "name": "Samuel Attard",

--- a/tasks/grover.js
+++ b/tasks/grover.js
@@ -90,7 +90,6 @@ module.exports = function(grunt) {
             cmd = path.resolve('' + path.normalize('node_modules/.bin/grover')),
             cb = this.async(),
             execPath;
-            grunt.log.ok('grover exec: ' + cmd);
 
 
         if (typeof options.path === 'string') {
@@ -104,7 +103,7 @@ module.exports = function(grunt) {
         }
 
         if (typeof options['execution-path'] === 'string') {
-            grunt.log.ok('exec: ' + options['execution-path']);
+            grunt.log.ok('execution-path: ' + options['execution-path']);
             execPath = path.resolve(options['execution-path']);
         }
 
@@ -170,7 +169,7 @@ module.exports = function(grunt) {
 	} else {
             grunt.fail.fatal('phantomjs binary could not be found');
         }
-        grunt.log.ok(execPath);
+        grunt.log.ok('Executing from: ' + execPath);
         exec(cmd, {cwd: execPath}, function(error, stdout, stderr) {
             grunt.log.ok('cwd: ' + options.cwd);
             if (error !== null && stderr === '') {

--- a/tasks/grover.js
+++ b/tasks/grover.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
                 port: 8000,
                 'phantom-bin': phantomPath,
                 'no-run': false,
-                'execution-path': false,
+                cwd: false,
                 coverage: {
                     on: false,
                     warn: 80,
@@ -102,9 +102,9 @@ module.exports = function(grunt) {
             grunt.fail.fatal('The path option must be set to a string');
         }
 
-        if (typeof options['execution-path'] === 'string') {
-            grunt.log.ok('execution-path: ' + options['execution-path']);
-            execPath = path.resolve(options['execution-path']);
+        if (typeof options.cwd === 'string') {
+            grunt.log.ok('cwd: ' + options.cwd);
+            execPath = path.resolve(options.cwd);
         }
 
 
@@ -169,9 +169,7 @@ module.exports = function(grunt) {
 	} else {
             grunt.fail.fatal('phantomjs binary could not be found');
         }
-        grunt.log.ok('Executing from: ' + execPath);
         exec(cmd, {cwd: execPath}, function(error, stdout, stderr) {
-            grunt.log.ok('cwd: ' + options.cwd);
             if (error !== null && stderr === '') {
                 stderr = 'There were test failures, please check the log';
             }

--- a/tasks/grover.js
+++ b/tasks/grover.js
@@ -78,6 +78,7 @@ module.exports = function(grunt) {
                 port: 8000,
                 'phantom-bin': phantomPath,
                 'no-run': false,
+                'execution-path': false,
                 coverage: {
                     on: false,
                     warn: 80,
@@ -86,18 +87,27 @@ module.exports = function(grunt) {
                     sourcePrefix: false
                 }
             }),
-            cmd = '' + path.normalize('node_modules/.bin/grover'),
-            cb = this.async();
+            cmd = path.resolve('' + path.normalize('node_modules/.bin/grover')),
+            cb = this.async(),
+            execPath;
+            grunt.log.ok('grover exec: ' + cmd);
+
 
         if (typeof options.path === 'string') {
             if (glob.sync(options.path).length !== 0) {
-                cmd += ' ' + options.path;
+                cmd += ' ' + path.resolve(options.path);
             } else {
                 grunt.fail.fatal('The specified path matches no files');
             }
         } else {
             grunt.fail.fatal('The path option must be set to a string');
         }
+
+        if (typeof options['execution-path'] === 'string') {
+            grunt.log.ok('exec: ' + options['execution-path']);
+            execPath = path.resolve(options['execution-path']);
+        }
+
 
         switch (options.logLevel) {
             case 0:
@@ -119,7 +129,7 @@ module.exports = function(grunt) {
         cmd += stringVar(options.suffix, 's');
         if (typeof options.outfile === 'string') {
             grunt.file.write(options.outfile, '');
-            cmd += ' -o ' + path.normalize(options.outfile);
+            cmd += ' -o ' + path.resolve(options.outfile);
             if (outputTypes.indexOf(options.outtype) !== -1) {
                 cmd += boolVar(true, '-' + options.outtype);
             } else {
@@ -143,25 +153,26 @@ module.exports = function(grunt) {
             cmd += numVar(options.coverage.warn, '-coverage-warn');
             if (typeof options.coverage.istanbul === 'string') {
                 grunt.file.mkdir(options.coverage.istanbul);
-                cmd += ' --istanbul-report ' + path.normalize(options.coverage.istanbul);
+                cmd += ' --istanbul-report ' + path.resolve(options.coverage.istanbul);
             }
             if (typeof options.coverage.reportFile === 'string') {
                 grunt.file.write(options.coverage.reportFile, '');
-                cmd += ' -co ' + path.normalize(options.coverage.reportFile);
+                cmd += ' -co ' + path.resolve(options.coverage.reportFile);
             }
             cmd += pathVar(options.coverage.sourcePrefix, 'sp');
         }
 
         if (typeof options['phantom-bin'] === 'string' && grunt.file.exists(options['phantom-bin'])) {
-            cmd += ' --phantom-bin ' + path.normalize(options['phantom-bin']);
+            cmd += ' --phantom-bin ' + path.resolve(options['phantom-bin']);
         } else if (grunt.file.exists(phantomPath)) {
             grunt.log.ok('Using default node phantomjs path');
-            cmd += ' --phantom-bin ' + path.normalize(phantomPath);
+            cmd += ' --phantom-bin ' + path.resolve(phantomPath);
 	} else {
             grunt.fail.fatal('phantomjs binary could not be found');
         }
-
-        exec(cmd, function(error, stdout, stderr) {
+        grunt.log.ok(execPath);
+        exec(cmd, {cwd: execPath}, function(error, stdout, stderr) {
+            grunt.log.ok('cwd: ' + options.cwd);
             if (error !== null && stderr === '') {
                 stderr = 'There were test failures, please check the log';
             }


### PR DESCRIPTION
In order to get our usage of the grover command working, it became necessary to change the cwd in which the command was executed. Since it is possible to pass the cwd as a parameter to the exec call, it seemed reasonable to add the option to the grunt execution and pass it through to the exec call.
